### PR TITLE
license doc typos #297

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ####Contributing to zmNinja
 
-The source code will always be available under CCSA-NC. If you'd like to contribute please know that if your changes are accepted and merged they will make it to the App/Play Store when I publish the app. This does not entitle you to any renumeration - If you still would like to contribute and make this solution better, please go right ahead. If you feel this prohibits you from contributing, please create a bug report or enhancement request via the github issue tracker and I'll incorporate it when I have time/agree its a good idea.
+The source code will always be available under CC BY-NC-SA 4.0. If you'd like to contribute please know that if your changes are accepted and merged they will make it to the App/Play Store when I publish the app. This does not entitle you to any renumeration - If you still would like to contribute and make this solution better, please go right ahead. If you feel this prohibits you from contributing, please create a bug report or enhancement request via the github issue tracker and I'll incorporate it when I have time/agree its a good idea.
 
 Thanks.
 

--- a/LICENSE
+++ b/LICENSE
@@ -7,7 +7,7 @@ For Desktop Clients Binaries:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Desktop clients binaries free to download and use ONLY for users
 who are using the desktop client with the free and open source ZoneMinder
-software. If you are selling a service based on zoneminder and are either distributing the Desktop Client to your users or asking your users to use the desktop client by download it themselves, you are violating the non-commercial use. You will need to procure a license before you do so.
+software. If you are selling a service based on ZoneMinder and are either distributing the Desktop Client to your users or asking your users to use the desktop client by download it themselves, you are violating the non-commercial use. You will need to procure a license before you do so.
 
 
 Source Code License

--- a/LICENSE
+++ b/LICENSE
@@ -44,7 +44,7 @@ http://packery.metafizzy.co
 A commercial single developer license has been purchased for the same.
 Note that this license allows me (pliablepixels) to use Packery for commercial
 apps that I develop (such as zmNinja). Given that I publish my source under
-CCSA-NC-SA, you can compile the code for your personal use (non commercial purposes)
+CC BY-NC-SA 4.0, you can compile the code for your personal use (non commercial purposes)
 and continue to use packery. This is compliant to Packery's license too, where they
 prohibit other developers to build for profit using the license I purchased.
 

--- a/LICENSE
+++ b/LICENSE
@@ -4,15 +4,14 @@ The apps in Apple App store and Google Play store can be used for any purpose (p
 
 
 For Desktop Clients Binaries: 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Desktop clients binaries free to download and use ONLY for users
 who are using the desktop client with the free and open source ZoneMinder
 software. If you are selling a service based on ZoneMinder and are either distributing the Desktop Client to your users or asking your users to use the desktop client by download it themselves, you are violating the non-commercial use. You will need to procure a license before you do so.
 
 
 Source Code License
-~~~~~~~~~~~~~~~~~~~~~~
-
+~~~~~~~~~~~~~~~~~~~
 The source code of zmNinja is dual licensed.
 
 a) The code is free for personal, non commercial use
@@ -24,9 +23,8 @@ Please contact pliablepixels@gmail.com
 
 
 
-
 Third Party credits
-=======================
+===================
 Ninja icon;
 https://openclipart.org/detail/172393/ninja-logo
 License: https://openclipart.org/share

--- a/LICENSE
+++ b/LICENSE
@@ -45,11 +45,11 @@ A commercial single developer license has been purchased for the same.
 Note that this license allows me (pliablepixels) to use Packery for commercial
 apps that I develop (such as zmNinja). Given that I publish my source under
 CC BY-NC-SA 4.0, you can compile the code for your personal use (non commercial purposes)
-and continue to use packery. This is compliant to Packery's license too, where they
+and continue to use Packery. This is compliant to Packery's license too, where they
 prohibit other developers to build for profit using the license I purchased.
 
 If however you purchase the source code from me, you will
-still have to purchase an additional license for packery from David via http://packery.metafizzy.co/#commercial-license
+still have to purchase an additional license for Packery from David via http://packery.metafizzy.co/#commercial-license
 It's very cheap ($25 for unlimited products by one developer).
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -19,7 +19,7 @@ a) The code is free for personal, non commercial use
 http://creativecommons.org/licenses/by-nc-sa/4.0/
 In summary: Share Alike, Adapt,Attribute, NonCommercial
 
-b) zmNinja source code is also open for commerical licensing and white-labeling.
+b) zmNinja source code is also open for commercial licensing and white-labeling.
 Please contact pliablepixels@gmail.com
 
 


### PR DESCRIPTION
Several trivial typo corrections to the license doc and a minor change to contributing.md to align with the license doc.

The assumption in this pr is that you intended to reference CC BY-NC-SA 4.0 as this was the url you provided.

Thanks for your generous licencing.