### PR TITLE
Added Global Configuration function for monitors

### DIFF
--- a/www/js/MonitorCtrl.js
+++ b/www/js/MonitorCtrl.js
@@ -6,8 +6,8 @@
 // refer to comments in EventCtrl for the modal stuff. They are almost the same
 
 angular.module('zmApp.controllers')
-    .controller('zmApp.MonitorCtrl', ['$ionicPopup', 'zm', '$scope', 'ZMDataModel', 'message', '$ionicSideMenuDelegate', '$ionicLoading', '$ionicModal', '$state', '$http', '$rootScope', '$timeout', '$ionicHistory', '$ionicPlatform', '$translate',
-                               function ($ionicPopup, zm, $scope, ZMDataModel, message, $ionicSideMenuDelegate, $ionicLoading, $ionicModal, $state, $http, $rootScope, $timeout, $ionicHistory, $ionicPlatform, $translate) {
+    .controller('zmApp.MonitorCtrl', ['$ionicPopup', 'zm', '$scope', 'ZMDataModel', 'message', '$ionicSideMenuDelegate', '$ionicLoading', '$ionicModal', '$state', '$http', '$rootScope', '$timeout', '$ionicHistory', '$ionicPlatform', '$translate', '$q',
+                               function ($ionicPopup, zm, $scope, ZMDataModel, message, $ionicSideMenuDelegate, $ionicLoading, $ionicModal, $state, $http, $rootScope, $timeout, $ionicHistory, $ionicPlatform, $translate, $q) {
 
 
             //-----------------------------------------------------------------------
@@ -86,6 +86,17 @@ angular.module('zmApp.controllers')
                 //console.log("called with " + monitorId + ":" + enabled + ":" + func);
                 if (enabled == '1') checked = true;
 
+                //if monitorId is not specified, all monitors will be changed 
+                var monitorsIds = new Array();
+                if (monitorId == '') {
+                    for (var i = 0; i < $scope.monitors.length; i++) {
+                        monitorsIds[i] = $scope.monitors[i].Monitor.Id;
+                    }
+                }
+                else {
+                        monitorsIds[0] = monitorId;
+                }
+
                 $scope.monFunctions = [
                     {
                         text: $translate.instant('kMonModect'),
@@ -114,8 +125,11 @@ angular.module('zmApp.controllers')
         ];
 
                 $scope.monfunc = {
+                    mymonitorsIds: monitorsIds,
                     myfunc: func,
-                    myenabled: checked
+                    myenabled: checked,
+                    myfailedIds: new Array(),
+                    mypromises: new Array()
                 };
 
                 $rootScope.zmPopup = $ionicPopup.show({
@@ -133,87 +147,93 @@ angular.module('zmApp.controllers')
                         {
                             text: $translate.instant('kButtonSave'),
                             onTap: function (e) {
+                                $scope.monfunc.mymonitorsIds.forEach( function(item, index) {
+                                    ZMDataModel.zmDebug("MonitorCtrl:changeConfig selection:" + $scope.monfunc.myenabled +
+                                        $scope.monfunc.myfunc);
+                                    var loginData = ZMDataModel.getLogin();
+                                    var apiRestart = loginData.apiurl + "/states/change/restart.json";
+                                    var apiMon = loginData.apiurl + "/monitors/" + item + ".json";
 
-                                ZMDataModel.zmDebug("MonitorCtrl:changeConfig selection:" + $scope.monfunc.myenabled +
-                                    $scope.monfunc.myfunc);
-                                var loginData = ZMDataModel.getLogin();
-                                var apiRestart = loginData.apiurl + "/states/change/restart.json";
-                                var apiMon = loginData.apiurl + "/monitors/" + monitorId + ".json";
+                                    ZMDataModel.zmDebug("MonitorCtrl: URLs for changeConfig save:" + apiMon);
 
-                                ZMDataModel.zmDebug("MonitorCtrl: URLs for changeConfig save:" + apiMon);
+                                    var isEnabled = "";
+                                    isEnabled = ($scope.monfunc.myenabled == true) ? '1' : '0';
 
-                                var isEnabled = "";
-                                isEnabled = ($scope.monfunc.myenabled == true) ? '1' : '0';
+                                    $ionicLoading.show({
+                                        template: $translate.instant('kApplyingChanges') + "...",
+                                        noBackdrop: true,
+                                        duration: zm.largeHttpTimeout,
+                                    });
 
-                                $ionicLoading.show({
-                                    template: $translate.instant('kApplyingChanges') + "...",
-                                    noBackdrop: true,
-                                    duration: zm.largeHttpTimeout,
-                                });
+                                    var httpPromise = $http({
+                                        url: apiMon,
+                                        method: 'post',
+                                        headers: {
+                                            'Content-Type': 'application/x-www-form-urlencoded',
+                                            'Accept': '*/*',
+                                        },
+                                        transformRequest: function (obj) {
+                                            var str = [];
+                                            for (var p in obj)
+                                                str.push(encodeURIComponent(p) + "=" +
+                                                    encodeURIComponent(obj[p]));
+                                            var foo = str.join("&");
+                                            // console.log("****RETURNING " + foo);
+                                            ZMDataModel.zmDebug("MonitorCtrl: parmeters constructed: " + foo);
+                                            return foo;
+                                        },
+                                        data: {
+                                            'Monitor[Function]': $scope.monfunc.myfunc,
+                                            'Monitor[Enabled]': isEnabled,
+                                        }
 
-                                $http({
-                                    url: apiMon,
-                                    method: 'post',
-                                    headers: {
-                                        'Content-Type': 'application/x-www-form-urlencoded',
-                                        'Accept': '*/*',
-                                    },
-                                    transformRequest: function (obj) {
-                                        var str = [];
-                                        for (var p in obj)
-                                            str.push(encodeURIComponent(p) + "=" +
-                                                encodeURIComponent(obj[p]));
-                                        var foo = str.join("&");
-                                        // console.log("****RETURNING " + foo);
-                                        ZMDataModel.zmDebug("MonitorCtrl: parmeters constructed: " + foo);
-                                        return foo;
-                                    },
-                                    data: {
-                                        'Monitor[Function]': $scope.monfunc.myfunc,
-                                        'Monitor[Enabled]': isEnabled,
-                                    }
-
-                                })
-
-                                // I am not restarting ZM after monitor change
-
-                                .success(function () {
-                                        $ionicLoading.hide();
+                                    })
+                                    .success(function () {
                                         ZMDataModel.zmDebug("MonitorCtrl: Not restarting ZM - Make sure you have the patch installed in MonitorsController.php or this won't work");
-                                        doRefresh();
-                                        /* ZMDataModel.zmDebug ("MonitorCtrl: Restarting ZM");
-                                         $ionicLoading.show({
-                                             template: "Successfully changed Monitor. Please wait, restarting ZoneMinder...",
-                                             noBackdrop: true,
-                                             duration: zm.largeHttpTimeout,
-                                         });
-                                         $http.post(apiRestart)
-                                             .then(function (success) {
-                                                     $ionicLoading.hide();
-                                                     var refresh = ZMDataModel.getMonitors(1);
-                                                     refresh.then(function (data) {
-                                                         $scope.monitors = data;
-                                                         $scope.$broadcast('scroll.refreshComplete');
-                                                     });
-
-                                                 },
-                                                 function (error) {
-                                                     $ionicLoading.hide();
-
-                                                 }
-                                             );*/
-
                                     })
                                     .error(function (data, status, headers, config) {
                                         ZMDataModel.zmDebug("MonitorCtrl: Error changing monitor " + JSON.stringify(data));
-                                        $ionicLoading.hide();
+                                        $scope.monfunc.myfailedIds.push(item);
+                                    });
+
+                                    $scope.monfunc.mypromises.push(httpPromise);
+                                });
+
+                                $q.all($scope.monfunc.mypromises).then(function(e) {
+                                    $ionicLoading.hide();
+                                    // if there's a failed ID, an error has occurred
+                                    if ($scope.monfunc.myfailedIds.length != 0) {
                                         $ionicLoading.show({
-                                            template: $translate.instant('kErrorChangingMonitors') + "...",
+                                            template: $translate.instant('kErrorChangingMonitors') + ". Monitor IDs : " + $scope.monfunc.myfailedIds.toString(),
                                             noBackdrop: true,
                                             duration: 3000,
                                         });
-                                    });
+                                    }
+                                    else {
+                                    // I am not restarting ZM after monitor change
+                                        /* ZMDataModel.zmDebug ("MonitorCtrl: Restarting ZM");
+                                        $ionicLoading.show({
+                                            template: "Successfully changed Monitor. Please wait, restarting ZoneMinder...",
+                                            noBackdrop: true,
+                                            duration: zm.largeHttpTimeout,
+                                        });
+                                        $http.post(apiRestart)
+                                            .then(function (success) {
+                                                $ionicLoading.hide();
+                                                var refresh = ZMDataModel.getMonitors(1);
+                                                refresh.then(function (data) {
+                                                    $scope.monitors = data;
+                                                    $scope.$broadcast('scroll.refreshComplete');
+                                                });
 
+                                             },
+                                             function (error) {
+                                                 $ionicLoading.hide();
+
+                                             });*/
+                                        doRefresh();
+                                    }
+                                });
                             }
 
 

--- a/www/lang/locale-en.json
+++ b/www/lang/locale-en.json
@@ -114,6 +114,7 @@
     "kFrom"                      :"From",
     "kFromDate"                  :"From Date",
     "kFromTime"                  :"From Time",
+    "kGlobalConfiguration"       :"Global Configuration",
     "kGraphAlarmed"              :"alarmed",
     "kGraphAll"                  :"all",
     "kGraphError"                :"there was an error rendering the graph. Please see logs",

--- a/www/templates/monitors.html
+++ b/www/templates/monitors.html
@@ -10,6 +10,10 @@
     <ion-content overflow-scroll="false">
        <ion-refresher pulling-text="Pull to reload Monitors..." spinner="bubbles" on-refresh="doRefresh()">
         </ion-refresher>
+            <div style="float:right;margin-top:3px;margin-right:8px;"> 
+                <a class="button button-small icon icon-left icon ion-gear-a"
+                   href="" ng-click="changeConfig('GLOBAL', '','1','Monitor');">{{'kGlobalConfiguration' | translate}}</a>
+            </div><br/>
             <div class="list card" ng-repeat="monitor in monitors">
                 <div class="item" ng-style="{'background-color': monitor.Monitor.Enabled=='1'?'white':'white'}">
                     <div ng-if="monitor.Monitor.Enabled == '1'">


### PR DESCRIPTION
Hello,

since in my environment i have got a lot of cameras, and users need to activate/deactivate recording, motion detection and other functions when they need to, i had another requirement: being able to change monitors functions for every monitor configured in ZM.
the only way that i found on zmNinja to perform that task was to manually select each monitor changing the function one by one.
this is not acceptable when you have more than 10 cameras.

so i modified the changeConfig routine and added a "Global Configuration" button in the monitor view in order to solve that problem.

i tested this in different ways on a desktop environment and it seems to work pretty well, exceptions included.

let me know if you think that it could be a useful merge for your project and if you want to ask me anything about what has been coded.
your usual tweaks and improvements are most certainly welcome.

thank you.