### PR TITLE
use corrent icon path

### DIFF
--- a/electron_js/main.js
+++ b/electron_js/main.js
@@ -56,7 +56,7 @@ function createAlternateWindow() {
     y: 10,
     width: 800,
     height: 800,
-    icon: path.join(__dirname, '/../icon.png'),
+    icon: path.join(__dirname, '/../resources/icon.png'),
     webPreferences:{nodeIntegration:false}});
 
     const startUrl = process.env.ELECTRON_START_URL || url.format({
@@ -64,7 +64,7 @@ function createAlternateWindow() {
       protocol: 'file:',
       slashes: true
     });
-    
+
     newWin.loadURL(startUrl);
 
 }
@@ -106,12 +106,12 @@ const mx = globalShortcut.register('CommandOrControl+Alt+F', () => {
         y: mainWindowState.y,
         width: mainWindowState.width,
         height: mainWindowState.height,
-        icon: path.join(__dirname, '/../icon.png'),
+        icon: path.join(__dirname, '/../resources/icon.png'),
         webPreferences:{nodeIntegration:false}});
 //
     console.log (__dirname+'/../icon.png');
 
-     
+
 
 
     win.webContents.session.webRequest.onHeadersReceived({}, (d, c) => {
@@ -151,7 +151,7 @@ const mx = globalShortcut.register('CommandOrControl+Alt+F', () => {
 
  // const menu = Menu.buildFromTemplate(template)
  // Menu.setApplicationMenu(menu)
- 
+
 
  const template = [
   {

--- a/electron_js/main.js
+++ b/electron_js/main.js
@@ -109,7 +109,7 @@ const mx = globalShortcut.register('CommandOrControl+Alt+F', () => {
         icon: path.join(__dirname, '/../resources/icon.png'),
         webPreferences:{nodeIntegration:false}});
 //
-    console.log (__dirname+'/../icon.png');
+    console.log (path.join(__dirname, '/../resources/icon.png'));
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zmninjapro",
   "description": "Home security mobile app for ZoneMinder",
-  "version": "1.3.022",
+  "version":"1.3.025",
   "displayName": "zmNinja",
   "author": "Pliable Pixels",
   "license": "custom see LICENSE.md",
@@ -131,7 +131,8 @@
     "files": [
       "electron_js/main.js",
       "www/**/*",
-      "!node_modules/**/*"
+      "!node_modules/**/*",
+      "resources/icon.png"
     ],
     "extraResources": [
       "node_modules/electron-window-state/**/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zmninjapro",
   "description": "Home security mobile app for ZoneMinder",
-  "version":"1.3.025",
+  "version":"1.3.022",
   "displayName": "zmNinja",
   "author": "Pliable Pixels",
   "license": "custom see LICENSE.md",


### PR DESCRIPTION
The icon path used was incorrect, resulting in missing icons (including on Windows if running from source with `npm run electron`). I guess electron-builder would fallback to one of the icons set in package.json if none was set at runtime for Windows. The Linux builds apparently don't do that. This PR fixes this [issue posted on electron-builder](https://github.com/electron-userland/electron-builder/issues/3332).

Also you might want to get rid of that log statement now. I assume that was added to debug this issue. I didn't bother updating it with the new path used.