### PR TITLE
Fixes double definition in www/js/app.js

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1134,7 +1134,7 @@ angular.module('zmApp', [
 
                 if (!succ.version) {
                   NVRDataModel.debug("API login returned fake success, going back to webscrape");
-                  var ld = NVRDataModel.getLogin();
+                  ld = NVRDataModel.getLogin();
                   ld.loginAPISupported = false;
                   NVRDataModel.setLogin(ld);
 
@@ -1165,7 +1165,7 @@ angular.module('zmApp', [
                   }
                 }
 
-                ldg = NVRDataModel.getLogin();
+                var ldg = NVRDataModel.getLogin();
                 ldg.loginAPISupported = true;
                 NVRDataModel.setLogin(ldg);
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1165,7 +1165,7 @@ angular.module('zmApp', [
                   }
                 }
 
-                var ldg = NVRDataModel.getLogin();
+                ldg = NVRDataModel.getLogin();
                 ldg.loginAPISupported = true;
                 NVRDataModel.setLogin(ldg);
 
@@ -1182,7 +1182,7 @@ angular.module('zmApp', [
 
               } catch (e) {
                 NVRDataModel.debug("Login API approach did not work...");
-                var ld = NVRDataModel.getLogin();
+                ld = NVRDataModel.getLogin();
                 ld.loginAPISupported = false;
                 NVRDataModel.setLogin(ld);
                 loginWebScrape()


### PR DESCRIPTION
There was double defenition of ld variable in www/js/app.js. This double def made `cordova prepare` fail with `UnhandledPromiseRejectionWarning` during Android app building