### PR TITLE
Only filter events on the Event Montage view (fixes #844)

### DIFF
--- a/www/js/EventCtrl.js
+++ b/www/js/EventCtrl.js
@@ -97,11 +97,15 @@ angular.module('zmApp.controllers')
       $ionicListDelegate.canSwipeItems(true);
      // NVR.debug("enabling options swipe");
 
-      // see if we come from monitors, if so, don't filter events
-      if ($ionicHistory.backTitle() == 'Monitors') {
-        showHiddenMonitors = true;
-      } else {
+      // only filter events on the Event Montage view, not monitors,
+      // event viewer, etc.
+      // we can't easily whitelist the views that should always show
+      // them because the event viewer's title is a time based string,
+      // not a static one like other views.
+      if ($ionicHistory.backTitle() != 'Event Montage') {
         showHiddenMonitors = false;
+      } else {
+        showHiddenMonitors = true;
       }
 
       if (NVR.getLogin().useLocalTimeZone) {


### PR DESCRIPTION
This is a plausible patch to get events for monitors which are hidden in the Montage view shown in the Events List view. I have a feeling that I might be missing another view or two that should filter events, so take this with a grain of salt. I tried digging back in the history to try to see why, but it looks like this code has existed since the first commit of the repo.

I'm not setup to build android apps at the moment, so I wasn't able to build or test this.