### PR TITLE
After resize scroll the view back to the event we were looking at

### DIFF
--- a/www/js/EventCtrl.js
+++ b/www/js/EventCtrl.js
@@ -96,7 +96,7 @@ angular.module('zmApp.controllers')
   
     });
     
-    function getRowHeight(event) {
+    $scope.getRowHeight = function (event) {
         var ld = NVR.getLogin();
         var rowHeight = 134; // ViewThumbs == none
         var scrubHeight = 274;
@@ -625,7 +625,7 @@ angular.module('zmApp.controllers')
 
             myevents[i].Event.MonitorName = NVR.getMonitorName(myevents[i].Event.MonitorId);
             myevents[i].Event.ShowScrub = false;
-            myevents[i].Event.rowHeight = getRowHeight(myevents[i]);
+            myevents[i].Event.rowHeight = $scope.getRowHeight(myevents[i]);
             // now construct base path
         
 
@@ -2235,7 +2235,7 @@ angular.module('zmApp.controllers')
         var eventHeightCounter = 0;
         //loop until we pass the event...
         for (var i = 0; i < $scope.events.length; i++) {
-            eventHeightCounter = eventHeightCounter + getRowHeight($scope.events[i]);
+            eventHeightCounter = eventHeightCounter + $scope.getRowHeight($scope.events[i]);
             if ( eventHeightCounter > scrl ) {
                 $scope.navTitle = ($scope.events[i].Event.humanizeTime);
                 break;
@@ -2332,13 +2332,13 @@ angular.module('zmApp.controllers')
 
         NVR.debug("EventCtrl:Old event scrub will hide now");
         oldEvent.Event.ShowScrub = false;
-        oldEvent.Event.rowHeight = getRowHeight(oldEvent);
+        oldEvent.Event.rowHeight = $scope.getRowHeight(oldEvent);
         oldEvent = "";
       }
       
 
       event.Event.ShowScrub = !event.Event.ShowScrub;
-      var currentRowHeight = getRowHeight(event);
+      var currentRowHeight = $scope.getRowHeight(event);
       event.Event.rowHeight = currentRowHeight;
 
       if (event.Event.ShowScrub == false) {
@@ -3048,7 +3048,7 @@ angular.module('zmApp.controllers')
               // console.log ("***** MULTISERVER STREAMING URL FOR EVENTS " + myevents[i].Event.streamingURL);
 
               //  console.log ("***** MULTISERVER BASE URL FOR EVENTS " + myevents[i].Event.recordingURL);
-              myevents[i].Event.rowHeight = getRowHeight(myevents[i]);
+              myevents[i].Event.rowHeight = $scope.getRowHeight(myevents[i]);
               myevents[i].Event.ShowScrub = false;
 
 
@@ -3234,7 +3234,7 @@ angular.module('zmApp.controllers')
 
             myevents[currentPagePosition].Event.MonitorName = NVR.getMonitorName(myevents[currentPagePosition].Event.MonitorId);
             myevents[currentPagePosition].Event.ShowScrub = false;
-            myevents[currentPagePosition].Event.rowHeight = getRowHeight(myevents[currentPagePosition]);
+            myevents[currentPagePosition].Event.rowHeight = $scope.getRowHeight(myevents[currentPagePosition]);
 
             //myevents[currentPagePosition].Event.height = eventsListDetailsHeight;
             // now construct base path

--- a/www/templates/events.html
+++ b/www/templates/events.html
@@ -34,7 +34,7 @@
       <ion-list show-delete="eventList.showDelete">
 
         <ion-item force-refresh-images="true" collection-repeat="event in events| filter:search.text |  eventListFilter"
-          force-refresh-images=true item-height="event.Event.rowHeight" id="item-{{$index}}"
+          force-refresh-images=true item-height="getRowHeight(event)" id="item-{{$index}}"
           on-swipe-left="checkSwipe($index);" force-refresh-images="true">
 
           <!-- item headers: date/time -->


### PR DESCRIPTION
Putting this here for long term work/review.

I wonder if we should restrict this code, so it only run when you rotate the phone? This may be acceptable compromise. If we don't scroll back after rotate, it's somewhat confusing, as we can be in a complete different part of the event list.