### PR TITLE
row height wasn't recalculating after changing thumb size

### DIFF
--- a/www/js/EventCtrl.js
+++ b/www/js/EventCtrl.js
@@ -108,21 +108,8 @@ angular.module('zmApp.controllers')
     });
     
     function scrollTo(eventNum, eventPos) {
-        var eventHeightCounter = 0;
-        var i = 0;
-        var lastEventHeight = 0;
-        //loop until we pass the event...
-        for (i = 0; i < $scope.events.length; i++) {
-        lastEventHeight = getRowHeight($scope.events[i]);
-        if ( i >= eventNum ) {
-            //$scope.navTitle = ($scope.events[i].Event.humanizeTime); // we don't need to update the navTitle as we're staying in the same place
-            break;
-        }
-        //console.log(getRowHeight($scope.events[i]));
-        eventHeightCounter = eventHeightCounter + lastEventHeight;
-        }
-        var scrl = eventHeightCounter + (lastEventHeight * eventPos);
-        //console.log("eventHeightCounter: " + eventHeightCounter + " lastEventHeight: " + lastEventHeight + ", scrl To " + scrl + ", len: " + $scope.events.length);
+        var scrl = (eventRowHeight * eventNum) + (eventRowHeight * eventPos);
+        //console.log("eventNum: " + eventNum + " eventPos: " + eventPos + ", scrl To " + scrl);
         NVR.debug("scrollTo: " + scrl);
         $ionicScrollDelegate.$getByHandle("mainScroll").scrollTo(0, scrl, false);
     }

--- a/www/js/EventCtrl.js
+++ b/www/js/EventCtrl.js
@@ -124,6 +124,7 @@ angular.module('zmApp.controllers')
         var tempMonHeight = 0;
         monitorHeight = 0;
         for (var i=0; i < $scope.monitors.length; i++) {
+          NVR.debug("setRowHeight, i: " + i + " Monitor.isChecked: " + $scope.monitors[i].Monitor.isChecked);
           if ($scope.monitors[i] != undefined && $scope.monitors[i].Monitor.isChecked) {
             var mw = $scope.monitors[i].Monitor.Width;
             var mh = $scope.monitors[i].Monitor.Height;
@@ -310,7 +311,6 @@ angular.module('zmApp.controllers')
     
     function recomputeRowHeights() {
       switchThumbClass();
-      setRowHeight();
       $scope.eventsBeingLoaded = true;
       $timeout (function() {
         NVR.debug ("recomputing all row heights");
@@ -3528,6 +3528,33 @@ angular.module('zmApp.controllers')
       refresh.then(function (data) {
         $scope.monitors = data;
         message = data;
+
+        if ($rootScope.monitorsFilter != undefined && $rootScope.monitorsFilter != '') {
+          NVR.debug("dorefresh monitorsFilter: " + $rootScope.monitorsFilter);
+          //$rootScope.monitorsFilter: /MonitorId =:5
+          //$rootScope.monitorsFilter: /MonitorId =:2/MonitorId =:3
+          //$rootScope.monitorsFilter: /MonitorId !=:5
+          var monitorIds = [];
+          ($rootScope.monitorsFilter.split("/")).forEach(function(monitorId, index) {
+            //console.log('Index: ' + index + ' Value: ' + monitorId);
+            //skip the first one as it's always blank
+            if (index)
+              monitorIds.push(monitorId.split(":")[1]);
+          });
+          var checked = true;
+          //if include listed monitors
+          if ($rootScope.monitorsFilter.includes("!=")) {
+            checked = false;
+          }
+          for (var i=0; i < $scope.monitors.length; i++) {
+            if ($scope.monitors[i] != undefined) {
+                if (monitorIds.includes($scope.monitors[i].Monitor.Id))
+                    $scope.monitors[i].Monitor.isChecked = checked;
+                else
+                    $scope.monitors[i].Monitor.isChecked = !checked;
+            }
+          }
+        }
 
         /* var ld = NVR.getLogin();
          if (ld.persistMontageOrder) {


### PR DESCRIPTION
also simplified scrollTo function (loop no longer required with fixed row heights).

Changes to doRefresh to apply "isChecked" based on monitorFilter actually squashes a number of minor issues around ensuring the monitor filter displays correctly on re-enter the filter screen too.